### PR TITLE
Support values with tabs

### DIFF
--- a/lib/streamingly/reducer.rb
+++ b/lib/streamingly/reducer.rb
@@ -25,7 +25,10 @@ module Streamingly
     end
 
     def reduce(line)
-      key, value = line.split("\t")
+      # Streaming Hadoop only treats the first tab as the delimiter between
+      # the key and value.  Additional tabs are grouped into the value:
+      # http://hadoop.apache.org/docs/r0.18.3/streaming.html#How+Does+Streaming+Work
+      key, value = line.split("\t", 2)
 
       if @prev_key != key
         results = flush

--- a/lib/streamingly/version.rb
+++ b/lib/streamingly/version.rb
@@ -1,3 +1,3 @@
 module Streamingly
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/spec/streamingly/reducer_spec.rb
+++ b/spec/streamingly/reducer_spec.rb
@@ -62,6 +62,29 @@ describe Streamingly::Reducer do
       end
     end
 
+    context "given a record with multiple tabs" do
+      let(:key) { 'key1' }
+      let(:value) { "asdf\tqwerty" }
+
+      let(:records) {
+        [
+          [key, value].join("\t"),
+        ]
+      }
+
+      let(:accumulator) { double(:accumulator, :flush => []) }
+
+      before do
+        accumulator_class.stub(:new).with(key) { accumulator }
+      end
+
+      it "treats only the first tab as the key/value delimiter and leaves the value untouched" do
+        accumulator.should_receive(:apply_value).with(value)
+
+        subject.reduce_over(records)
+      end
+    end
+
     context "when supplied with accumulator options" do
       let(:accumulator_options) { { foo: 'bar' } }
       subject { described_class.new(accumulator_class, accumulator_options) }


### PR DESCRIPTION
@kbarrette @accardi - This updates Streamingly's reducer to match Hadoop's behavior regarding tabs, which makes rekeying reducer output containing tabs (to support the Normalized Neptune transition) cleaner.
