### PR TITLE
If we call .split with two args, it should take two args

### DIFF
--- a/lib/streamingly/kv.rb
+++ b/lib/streamingly/kv.rb
@@ -11,7 +11,7 @@ module Streamingly
     end
 
     # TODO: remove .split from https://github.com/swipely/streamingly/blob/master/lib/streamingly/reducer.rb#L28
-    def split(char="\t")
+    def split(char="\t", limit=1)
       [key, value]
     end
   end

--- a/lib/streamingly/version.rb
+++ b/lib/streamingly/version.rb
@@ -1,3 +1,3 @@
 module Streamingly
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end


### PR DESCRIPTION
@mattgillooly 

This fixes a bug introduced in #2
