### PR TITLE
Make reducer catch errors so that processing will contiue in spite of lo...

### DIFF
--- a/spec/streamingly/reducer_spec.rb
+++ b/spec/streamingly/reducer_spec.rb
@@ -1,8 +1,42 @@
 require 'spec_helper'
 
+class TestAccumulator
+  attr_reader :applied_values, :raised_errors
+
+  def initialize
+    @applied_values = []
+    @raised_errors = []
+  end
+
+  def apply_value(value)
+    @applied_values << value
+  end
+
+  def flush
+    []
+  end
+
+  def on_error(error)
+    @raised_errors << error
+  end
+end
+
+class RaisesOnSingleCharAccumulator < TestAccumulator
+  def apply_value(value)
+    super(value)
+    raise ArgumentError, "Must not be a single character" if value.size == 1
+  end
+end
+
+class RaisesOnFlushAccumulator < TestAccumulator
+  def flush
+    raise RuntimeError, "Cannot flush when ya only have two pairs"
+  end
+end
+
 describe Streamingly::Reducer do
 
-  let(:accumulator_class) { double }
+  let(:accumulator_class) { double(:accumulator_class, :method_defined? => true) }
   subject { described_class.new(accumulator_class) }
 
   describe "#reduce_over" do
@@ -82,6 +116,118 @@ describe Streamingly::Reducer do
         accumulator.should_receive(:apply_value).with(value)
 
         subject.reduce_over(records)
+      end
+    end
+
+    context "given a record which will cause an exception" do
+      let(:key) { 'key1' }
+      let(:value1) { "a" }
+      let(:value2) { "abc" }
+      let(:records) {
+        [
+          [key, value1].join("\t"),
+          [key, value2].join("\t")
+        ]
+      }
+
+      let(:accumulator) { RaisesOnSingleCharAccumulator.new }
+
+      context "with error callback specified" do
+        before do
+          accumulator_class.stub(:new).with(key) { accumulator }
+        end
+
+        it "keeps processing after error applying value" do
+          subject.reduce_over(records)
+
+          expect(accumulator.applied_values).to eq([value1, value2])
+        end
+
+        it "calls supplied error callback" do
+          subject.reduce_over(records)
+
+          expect(accumulator.raised_errors.size).to eq(1)
+          raised_error = accumulator.raised_errors[0]
+          expect(raised_error.class).to eq(ArgumentError)
+        end
+      end
+
+      context "without error callback specified" do
+        let(:accumulator_class) { double(:accumulator_class, :method_defined? => false) }
+        subject { described_class.new(accumulator_class) }
+
+        before do
+            accumulator_class.stub(:new).with(key) { accumulator }
+        end
+
+        it "stops processing after error applying value" do
+          expect{ subject.reduce_over(records) }.to raise_error(ArgumentError)
+
+          expect(accumulator.applied_values).to eq([value1])
+          expect(accumulator.raised_errors.size).to eq(0)
+        end
+      end
+    end
+
+    context "given accumulator which fails on flush" do
+      let(:key1) { 'key1' }
+      let(:key2) { 'key2' }
+      let(:value1) { 'asdf' }
+      let(:value2) { 'qwerty' }
+
+      let(:records) {
+        [
+          [key1, value1].join("\t"),
+          [key2, value2].join("\t")
+        ]
+      }
+
+      let(:accumulator1) { RaisesOnFlushAccumulator.new }
+      let(:accumulator2) { TestAccumulator.new }
+
+      context "with error callback specified" do
+        before do
+          accumulator_class.stub(:new).with(key1) { accumulator1 }
+          accumulator_class.stub(:new).with(key2) { accumulator2 }
+        end
+
+        it "keeps processing after error applying value" do
+          subject.reduce_over(records)
+
+          expect(accumulator1.applied_values).to eq([value1])
+
+          expect(accumulator2.applied_values).to eq([value2])
+        end
+
+        it "calls supplied error callback" do
+          subject.reduce_over(records)
+
+          expect(accumulator1.raised_errors.size).to eq(1)
+          raised_error = accumulator1.raised_errors[0]
+          expect(raised_error.class).to eq(RuntimeError)
+
+          expect(accumulator2.raised_errors.size).to eq(0)
+        end
+      end
+
+      context "without error callback specified" do
+        let(:accumulator_class) { double(:accumulator_class, :method_defined? => false) }
+        subject { described_class.new(accumulator_class) }
+
+        before do
+          accumulator_class.stub(:new).with(key1) { accumulator1 }
+          accumulator_class.stub(:new).with(key2) { accumulator2 }
+        end
+
+        it "stops processing after error applying value" do
+          expect{ subject.reduce_over(records) }.to raise_error(RuntimeError)
+
+          expect(accumulator1.applied_values).to eq([value1])
+          expect(accumulator1.raised_errors.size).to eq(0)
+
+          expect(accumulator2.applied_values).to eq([])
+          expect(accumulator2.raised_errors.size).to eq(0)
+        end
       end
     end
 


### PR DESCRIPTION
...cal failures

@mattgillooly, @mguymon please review.
/cc @dstuebe

Context:
For a big data system, malformed input or other unexpected conditions may pop up a lot. Rather than having the reducer fail and stop on the first such input, it is often better to keep going and instead use some other mechanism to capture and document the failure (for instance, HoneyBadger exception reporting, etc.)

Solution:
This pull makes the reducer resilient to such errors.

Design tradeoffs:
1. Should this be make an option instead to ensure no changes to current behavior? I can see an argument for failing extremely loudly.
2. Should we add a limit on the number and/or percentage of failures allowed? This is to prevent systems like HoneyBadgers from being inundated w/ erroneous output.
