### PR TITLE
Streamingly SerDe should serialize Streamingly::KV as string rather than...

### DIFF
--- a/lib/streamingly/serde.rb
+++ b/lib/streamingly/serde.rb
@@ -8,6 +8,8 @@ module Streamingly
       case record
       when String
         record
+      when Streamingly::KV
+        record.to_s
       when Struct
         tokens = *record.map { |token|
           case token


### PR DESCRIPTION
... a generic struct. This is important when KVs are nested

@mattgillooly, please review.

Context:
Sometimes we want to nest KV pairs as supported by Hadoop. We should serialize so that they have multiple tabs.

Example:
Streamingly KV
  key: key1
  value: Streamingly KV
                key: key 2
                value: value

Serialized form before patch:
`"key1\tStreamingly::KV,\"#<struct Key2Type key2field=\"\"foo\"\",\"#<struct ValueType valuefield=\"\"bar\"\", >\""`
Serialized form after patch:
`"key1\tKey2Type,foo\tValueType,bar"`
