### PR TITLE
Streamingly SerDe::from_tabbed_csv can now deserialized nested and csv k...

### DIFF
--- a/lib/streamingly/serde.rb
+++ b/lib/streamingly/serde.rb
@@ -33,8 +33,22 @@ module Streamingly
     end
 
     def self.from_tabbed_csv(string)
-      k,v = string.split("\t")
-      KV.new(from_csv(k), from_csv(v))
+      k, v = string.split("\t", 2)
+      key = from_string_or_csv(k)
+      value = if v.include? "\t"
+                from_tabbed_csv(v)
+              else
+                from_string_or_csv(v)
+              end
+      KV.new(key, value)
+    end
+
+    def self.from_string_or_csv(string)
+      if string.include? ','
+        from_csv(string)
+      else
+        string
+      end
     end
 
     def self.resolve_class(class_name)


### PR DESCRIPTION
...v pairs properly

@mattgillooly, please review.

Context:
In many of our use cases, the Streamingly line can be a KV pair where they can be
1. Another KV pair (only values)
2. A CSV tuple of Struct + params
3. Just a plain string

This pulls adds the ability to deserialize all of them.
