### PR TITLE
Add nil guard for accumulator in reducer error handler

### DIFF
--- a/lib/streamingly/reducer.rb
+++ b/lib/streamingly/reducer.rb
@@ -51,7 +51,7 @@ module Streamingly
     end
 
     def on_error(error, error_context)
-      raise error unless @error_callback_defined
+      raise error unless @error_callback_defined && !@accumulator.nil?
       @accumulator.on_error(error, error_context)
     end
 


### PR DESCRIPTION
@mattgillooly, please review.

Context:
In reducer's reduce method, it is rare but possible (hit this recently) to have an exception be raised before any accumulators are initialized. In that case, the error handler should not attempt to call on_error for a nil accumulator class and should instead raise.
