### PR TITLE
Fall back to string if csv parsing fails

### DIFF
--- a/lib/streamingly/serde.rb
+++ b/lib/streamingly/serde.rb
@@ -45,11 +45,13 @@ module Streamingly
     end
 
     def self.from_string_or_csv(string)
-      if string.include? ','
-        from_csv(string)
+      if string.include? ','  # Likely a CSV
+        from_csv(string)  # Attempt to parse
       else
         string
       end
+    rescue CSV::MalformedCSVError  # Not actually CSV, fallback to string
+      string
     end
 
     def self.resolve_class(class_name)

--- a/spec/streamingly/serde_spec.rb
+++ b/spec/streamingly/serde_spec.rb
@@ -45,4 +45,18 @@ describe Streamingly::SerDe do
       expect(described_class.to_csv(record)).to eq 'Record,1,string_value'
     end
   end
+
+  describe '.from_string_or_csv' do
+    it 'returns CSV serialization for CSV string' do
+      expect(described_class.from_string_or_csv('1,2')).to eq ['1', '2']
+    end
+
+    it 'returns string if not containing a comma' do
+      expect(described_class.from_string_or_csv('foo')).to eq 'foo'
+    end
+
+    it 'returns string if containing a comma but not valid CSV' do
+      expect(described_class.from_string_or_csv('"foo,bar')).to eq '"foo,bar'
+    end
+  end
 end

--- a/spec/streamingly/serde_spec.rb
+++ b/spec/streamingly/serde_spec.rb
@@ -59,4 +59,12 @@ describe Streamingly::SerDe do
       expect(described_class.from_string_or_csv('"foo,bar')).to eq '"foo,bar'
     end
   end
+
+  describe '.from_tabbed_csv' do
+    it 'returns nested KV pair structure with the first tab as the split' do
+      expect(described_class.from_tabbed_csv("a\tb\tc")).to eq(
+        Streamingly::KV.new('a', Streamingly::KV.new('b', 'c'))
+      )
+    end
+  end
 end

--- a/spec/streamingly/serde_spec.rb
+++ b/spec/streamingly/serde_spec.rb
@@ -28,4 +28,21 @@ describe Streamingly::SerDe do
     end
   end
 
+  describe '.to_csv' do
+    it 'is identity function for a string' do
+      record = 'test_string'
+      expect(described_class.to_csv(record)).to eq record
+    end
+
+    it 'is equal to string version of Streamingly kv' do
+      record = Streamingly::KV.new('key', 'value')
+      expect(described_class.to_csv(record)).to eq record.to_s
+    end
+
+    it 'serializes struct to CSV, interpreting decimal fields as floats' do
+      Record = Struct.new(:number, :string)
+      record = Record.new(1, 'string_value')
+      expect(described_class.to_csv(record)).to eq 'Record,1,string_value'
+    end
+  end
 end


### PR DESCRIPTION
@mattgillooly, please review.

Context:
We sometimes encounter strings which contain commas but are not CSVs for deserialization. We should fallback to treating it as a string in that case.
