### PR TITLE
Only remove trailing nils from CSV

### DIFF
--- a/lib/streamingly/serde.rb
+++ b/lib/streamingly/serde.rb
@@ -26,8 +26,12 @@ module Streamingly
 
     def self.from_csv(string)
       tokens = CSV.parse_line(string)
+      return unless tokens.size > 0
       klass = resolve_class(tokens.first)
-      klass.new(*tokens[1..-1].compact)
+      tokens_arr = tokens.to_a
+      tokens_arr.pop while tokens_arr.last.nil?
+      tokens_arr.shift  # Remove leading class marker
+      klass.new(*tokens_arr)
     rescue NameError
       tokens
     end


### PR DESCRIPTION
@tlunter, FYI. Addresses badger https://app.honeybadger.io/projects/36371/faults/14749201/71235b4c-4696-11e5-838b-43c067c695bf#notice-params. We don't want to chomp nils in the middle like close time, only trailing ones.