### PR TITLE
Support passing in an error handler in case SerDe fails

### DIFF
--- a/lib/streamingly/serde_iterable.rb
+++ b/lib/streamingly/serde_iterable.rb
@@ -1,13 +1,24 @@
 module Streamingly
 
   class SerDeIterable
-    def initialize(iterable)
+    def initialize(iterable, error_handler = nil)
       @iterable = iterable
+      @error_handler = error_handler
+      @error_callback_defined = @error_handler &&
+                                @error_handler.method_defined?(:on_error)
     end
 
     def each
       @iterable.each do |line|
-        yield Streamingly::SerDe.from_tabbed_csv(line)
+        begin
+          yield Streamingly::SerDe.from_tabbed_csv(line)
+        rescue => error
+          if @error_callback_defined
+            @error_handler.send(:on_error, error, line: line)
+          else
+            raise error
+          end
+        end
       end
     end
   end

--- a/spec/streamingly/serde_iterable_spec.rb
+++ b/spec/streamingly/serde_iterable_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe Streamingly::SerDeIterable do
+  let(:iterable) { [1] }
+  let(:error) { StandardError.new('error') }
+
+  before do
+    allow(Streamingly::SerDe).to receive(:from_tabbed_csv).and_raise(error)
+  end
+
+  describe 'no error handler given' do
+    subject { described_class.new(iterable) }
+
+    it 'raises error when calling each' do
+      expect { subject.each }.to raise_error
+    end
+  end
+
+  describe 'given custom error handler' do
+    let(:error_handler) { double(:error_handler, method_defined?: true) }
+    subject { described_class.new(iterable, error_handler) }
+
+    it 'calls on_error method of provided handler' do
+      expect(error_handler).to receive(:on_error).with(error, line: 1)
+      expect { subject.each }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
@dstuebe, @mguymon, give option to pass in an error handler upon `SerDeIterable` parsing failure rather than just raise. Better than monkey patching every instance like https://github.com/dotswipely/normalize_neptune_pipeline/pull/146.

This enables fine grained error handling in pipelines.