### PR TITLE
Make on_error function in reducer public so on_error behaves properly

### DIFF
--- a/lib/streamingly/reducer.rb
+++ b/lib/streamingly/reducer.rb
@@ -20,7 +20,12 @@ module Streamingly
 
     end
 
-  private
+    def on_error(error, error_context)
+      raise error unless @error_callback_defined && !@accumulator.nil?
+      @accumulator.on_error(error, error_context)
+    end
+
+    private
 
     def flush
       @accumulator ? (@accumulator.flush || []).compact : []
@@ -50,11 +55,6 @@ module Streamingly
     rescue StandardError => error
       on_error(error, line: line)
       []
-    end
-
-    def on_error(error, error_context)
-      raise error unless @error_callback_defined && !@accumulator.nil?
-      @accumulator.on_error(error, error_context)
     end
 
     def new_accumulator(key)

--- a/lib/streamingly/serde_iterable.rb
+++ b/lib/streamingly/serde_iterable.rb
@@ -14,7 +14,7 @@ module Streamingly
           yield Streamingly::SerDe.from_tabbed_csv(line)
         rescue => error
           if @error_callback_defined
-            @error_handler.send(:on_error, error, line: line)
+            @error_handler.on_error(error, line: line)
           else
             raise error
           end

--- a/spec/streamingly/reducer_spec.rb
+++ b/spec/streamingly/reducer_spec.rb
@@ -41,6 +41,12 @@ describe Streamingly::Reducer do
   let(:accumulator_class) { double(:accumulator_class, :method_defined? => true) }
   subject { described_class.new(accumulator_class) }
 
+  describe '#on_error' do
+    it 'is exposed as public method' do
+      expect(subject).to respond_to(:on_error)
+    end
+  end
+
   describe "#reduce_over" do
 
     context "given records with the same key" do

--- a/spec/streamingly/serde_iterable_spec.rb
+++ b/spec/streamingly/serde_iterable_spec.rb
@@ -1,5 +1,11 @@
 require 'spec_helper'
 
+class TestErrorHandler
+  def on_error(error, context)
+    nil
+  end
+end
+
 describe Streamingly::SerDeIterable do
   let(:iterable) { [1] }
   let(:error) { StandardError.new('error') }
@@ -17,7 +23,7 @@ describe Streamingly::SerDeIterable do
   end
 
   describe 'given custom error handler' do
-    let(:error_handler) { double(:error_handler, respond_to?: true) }
+    let(:error_handler) { TestErrorHandler.new }
     subject { described_class.new(iterable, error_handler) }
 
     it 'calls on_error method of provided handler' do


### PR DESCRIPTION
@tlunter, `on_error` in reducer needed to be public to be able to return true for `respond_to?`.
